### PR TITLE
Fix process_refresh_queue refactor bugs.

### DIFF
--- a/gmn/src/d1_gmn/app/management/commands/process_refresh_queue.py
+++ b/gmn/src/d1_gmn/app/management/commands/process_refresh_queue.py
@@ -164,14 +164,14 @@ class Command(django.core.management.base.BaseCommand):
     d1_gmn.app.sysmeta.create_or_update(sysmeta_pyxb)
 
   def _assert_is_pid_of_native_object(self, pid):
-    if not d1_gmn.app.util.is_existing_object(pid):
+    if not d1_gmn.app.did.is_existing_object(pid):
       raise django.core.management.base.CommandError(
         u'Object referenced by PID does not exist or is not valid target for'
         u'System Metadata refresh. pid="{}"'.format(pid)
       )
 
   def _assert_pid_matches_request(self, sysmeta_pyxb, pid):
-    if d1_common.xml.uvalue(sysmeta_pyxb.identifier) != pid:
+    if d1_common.xml.get_rep_val(sysmeta_pyxb.identifier) != pid:
       raise django.core.management.base.CommandError(
         u'PID in retrieved System Metadata does not match the object for which '
         u'refresh was requested. pid="{}"'.format(pid)


### PR DESCRIPTION
The cron job for running process_refresh_queue was failing with : 
```
2017-12-06 17:47:27 ERROR    root process_refresh_queue System Metadata refresh failed with exception:
Traceback (most recent call last):
  File "/var/local/dataone/gmn_venv/local/lib/python2.7/site-packages/d1_gmn/app/management/commands/process_refresh_queue.py", line 91, in _process_refresh_request
    self._refresh(queue_model)
  File "/var/local/dataone/gmn_venv/local/lib/python2.7/site-packages/d1_gmn/app/management/commands/process_refresh_queue.py", line 118, in _refresh
    self._assert_is_pid_of_native_object(pid)
  File "/var/local/dataone/gmn_venv/local/lib/python2.7/site-packages/d1_gmn/app/management/commands/process_refresh_queue.py", line 167, in _assert_is_pid_of_native_object
    if not d1_gmn.app.did.is_existing_object(pid):
AttributeError: 'module' object has no attribute 'is_existing_object'
```

In commit idc98a668e60597fc9a00f845ae3fe204c61d1dc4
the gmn/src/d1_gmn/app/util.py class was refactored and
gmn/src/d1_gmn/app/did.py now has the is_existing_object() method.

Also, lib_common/src/d1_common/xml.py, the uvalue() method
was changed to get_req_val() commit 60e80bd97fd01254d254ddeeb9f21c08a30e1193.

Update gmn/src/d1_gmn/app/management/commands/process_refresh_queue.py
with the correct method locations.