### PR TITLE
docs: fix typo

### DIFF
--- a/gmn/doc/setup_ubuntu/setup-d1-stack.rst
+++ b/gmn/doc/setup_ubuntu/setup-d1-stack.rst
@@ -60,7 +60,7 @@ interactively, add::
 
   # DataONE paths
   export D1_ROOT_DIR="/var/local/dataone"
-  export GMN_VENV_DIR="${D1_ROOT_DIR}/gmn2_venv"
+  export GMN_VENV_DIR="${D1_ROOT_DIR}/gmn_venv"
   export GMN_PKG_DIR="${GMN_VENV_DIR}/lib/python2.7/site-packages/d1_gmn"
 
   # Use these as shortcuts from the shell. E.g., "cd $d1"


### PR DESCRIPTION
The bashrc variable uses gmn2_venv but the step before doesn't have the "2". The rest of your docs seem to use `gmn_venv` too.