### PR TITLE
Update paths in docs for gmn

### DIFF
--- a/gmn/doc/maintenance.rst
+++ b/gmn/doc/maintenance.rst
@@ -16,7 +16,7 @@ Upgrading the GMN 2.x software stack to the latest release
     $ cd /var/local/dataone/gmn_venv
     $ . ./bin/activate
     $ pip install --upgrade dataone.gmn
-    $ ./lib/site-packages/gmn/manage.py migrate
+    $ ./lib/site-packages/d1_gmn/manage.py migrate
     $ exit
     $ sudo service apache2 restart
 
@@ -30,7 +30,7 @@ The Node document contains information specific to a Node, such as the Member No
 
 Make the desired updates to the Node information::
 
-    $ sudo editor /var/local/dataone/gmn_venv/lib/site-packages/gmn/settings_site.py
+    $ sudo editor /var/local/dataone/gmn_venv/lib/site-packages/d1_gmn/settings_site.py
     $ sudo service apache2 restart
 
 Publish the updated Node document::
@@ -38,5 +38,5 @@ Publish the updated Node document::
     $ sudo su gmn
     $ cd /var/local/dataone/gmn_venv
     $ . ./bin/activate
-    $ ./lib/site-packages/gmn/manage.py node update
+    $ ./lib/site-packages/d1_gmn/manage.py node update
     $ exit

--- a/gmn/doc/setup-env-final.rst
+++ b/gmn/doc/setup-env-final.rst
@@ -6,6 +6,6 @@ Turn off stand-alone mode
 
 ::
 
-  $ sudo nano /var/local/dataone/gmn_venv/lib/python2.7/site-packages/gmn/settings.py
+  $ sudo nano /var/local/dataone/gmn_venv/lib/python2.7/site-packages/d1_gmn/settings.py
 
 * Set ``STAND_ALONE`` to ``False``.

--- a/gmn/doc/setup-env-tier.rst
+++ b/gmn/doc/setup-env-tier.rst
@@ -38,6 +38,6 @@ GMN supports all tiers. To select the tier for your Member Node, take the follow
 
 When you have determined which tier to use, edit ``settings.py``::
 
-  $ sudo nano /var/local/dataone/gmn_venv/lib/python2.7/site-packages/gmn/settings.py
+  $ sudo nano /var/local/dataone/gmn_venv/lib/python2.7/site-packages/d1_gmn/settings.py
 
 * Set TIER to 1, 2, 3 or 4.

--- a/gmn/doc/setup-migrate.rst
+++ b/gmn/doc/setup-migrate.rst
@@ -34,12 +34,12 @@ Install GMN v2 from PyPI::
 
 Configure GMN v2 instance and migrate settings from GMN v1::
 
-    $ sudo /var/local/dataone/gmn_venv/lib/python2.7/site-packages/gmn/deployment/migrate_v1_to_v2.sh
+    $ sudo /var/local/dataone/gmn_venv/lib/python2.7/site-packages/d1_gmn/deployment/migrate_v1_to_v2.sh
 
 Migrate contents from GMN v1::
 
     $ sudo -u gmn /var/local/dataone/gmn_venv/bin/python \
-    /var/local/dataone/gmn_venv/lib/python2.7/site-packages/gmn/manage.py \
+    /var/local/dataone/gmn_venv/lib/python2.7/site-packages/d1_gmn/manage.py \
     migrate_v1_to_v2
 
 Verify successful upgrade:


### PR DESCRIPTION
I'm upgrading to 2.4.2 and it seems paths have changed from /gmn/ to /d1_gmn/.

I think I've got all the spots in the docs. The only one I didn't change was https://github.com/DataONEorg/d1_python/blame/master/gmn/doc/setup-migrate.rst#L67 but I'm fairly certainly that's meant to stay like that because it refers to the v1 path.