### PR TITLE
Support Adding File Locations to the ORE

### DIFF
--- a/lib_common/src/d1_common/const.py
+++ b/lib_common/src/d1_common/const.py
@@ -90,7 +90,7 @@ ORE_NAMESPACE_DICT = {
     "dcterms": "http://purl.org/dc/terms/",
     "ore": "http://www.openarchives.org/ore/terms/",
     "foaf": "http://xmlns.com/foaf/0.1/",
-    "prov": "https://www.w3.org/ns/prov",
+    "prov": "http://www.w3.org/ns/prov#",
 }
 ORE_FORMAT_ID = "http://www.openarchives.org/ore/terms"
 ORE_SOFTWARE_ID = "DataONE.org Python ITK {}".format(VERSION)

--- a/lib_common/src/d1_common/const.py
+++ b/lib_common/src/d1_common/const.py
@@ -90,6 +90,7 @@ ORE_NAMESPACE_DICT = {
     "dcterms": "http://purl.org/dc/terms/",
     "ore": "http://www.openarchives.org/ore/terms/",
     "foaf": "http://xmlns.com/foaf/0.1/",
+    "prov": "https://www.w3.org/ns/prov",
 }
 ORE_FORMAT_ID = "http://www.openarchives.org/ore/terms"
 ORE_SOFTWARE_ID = "DataONE.org Python ITK {}".format(VERSION)

--- a/lib_common/src/d1_common/resource_map.py
+++ b/lib_common/src/d1_common/resource_map.py
@@ -40,6 +40,7 @@ Common RDF-XML namespaces:
   ore: <http://www.openarchives.org/ore/terms/>
   dcterms: <http://purl.org/dc/terms/>
   cito: <http://purl.org/spar/cito/>
+  prov: <http://www.w3.org/ns/prov#>
 
 Note:
 

--- a/lib_common/src/d1_common/resource_map.py
+++ b/lib_common/src/d1_common/resource_map.py
@@ -439,8 +439,8 @@ class ResourceMap(rdflib.ConjunctiveGraph):
             The on-disk location of the object
         """
         self._check_initialized()
-        resouremap_object = self.getObjectByPid(pid)
-        self.add(resouremap_object, PROV.atLocation, location)
+        resoure_map_member = self.getObjectByPid(pid)
+        self.add((resoure_map_member, PROV.atLocation, rdflib.term.Literal(location)))
 
     def getResourceMapPid(self):
         """Returns:

--- a/lib_common/src/d1_common/resource_map.py
+++ b/lib_common/src/d1_common/resource_map.py
@@ -62,6 +62,7 @@ import d1_common.url
 DCTERMS = rdflib.Namespace(d1_common.const.ORE_NAMESPACE_DICT["dcterms"])
 CITO = rdflib.Namespace(d1_common.const.ORE_NAMESPACE_DICT["cito"])
 ORE = rdflib.Namespace(d1_common.const.ORE_NAMESPACE_DICT["ore"])
+PROV = rdflib.Namespace(d1_common.const.ORE_NAMESPACE_DICT["prov"])
 
 
 def createSimpleResourceMap(ore_pid, scimeta_pid, sciobj_pid_list):
@@ -424,6 +425,21 @@ class ResourceMap(rdflib.ConjunctiveGraph):
             self.addResource(dpid)
             self.setDocumentedBy(dpid, scimeta_pid)
             self.setDocuments(scimeta_pid, dpid)
+
+    def setAtLocation(self, pid, location):
+        """Establishes a triple relationship between a pid and a file path.
+
+        ``pid`` atLocation ``location``.
+
+        Args:
+          pid: str
+            PID of the object whose location is being described
+          location: str
+            The on-disk location of the object
+        """
+        self._check_initialized()
+        resouremap_object = self.getObjectByPid(pid)
+        self.add(resouremap_object, PROV.atLocation, location)
 
     def getResourceMapPid(self):
         """Returns:

--- a/lib_common/src/d1_common/tests/test_resource_map.py
+++ b/lib_common/src/d1_common/tests/test_resource_map.py
@@ -459,3 +459,9 @@ class TestResourceMap(d1_test.d1_test_case.D1TestCase):
 
         for agg_pid in ore.getAggregatedScienceMetadataPids():
             assert unicode_pid in agg_pid
+
+    def test_1190(self, mn_client_v2):
+        ore = self._create()
+        ore.addResource("resource1_pid")
+        ore.setAtLocation("resource1_pid", "scripts/data_cleaning")
+        self.sample.assert_equals(ore, "set_at_location", mn_client_v2)

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_add_data_documents_by_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_add_data_documents_by_mn_v2.sample
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_add_metadata_document_by_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_add_metadata_document_by_mn_v2.sample
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_add_resource_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_add_resource_mn_v2.sample
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_init_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_init_mn_v2.sample
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_serialize_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_serialize_mn_v2.sample
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_set_at_location_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_set_at_location_mn_v2.sample
@@ -18,8 +18,8 @@ ore:Aggregation rdfs:label "Aggregation" ;
     rdfs:isDefinedBy ore: .
 
 <https://cn.dataone.org/cn/v2/resolve/resource1_pid> dcterms:identifier "resource1_pid" ;
-    cito:documents <https://cn.dataone.org/cn/v2/resolve/resource2_pid> ;
-    ore:isAggregatedBy <https://cn.dataone.org/cn/v2/resolve/ore_pid#aggregation> .
+    ore:isAggregatedBy <https://cn.dataone.org/cn/v2/resolve/ore_pid#aggregation> ;
+    prov:atLocation "scripts/data_cleaning" .
 
 <https://cn.dataone.org/cn/v2/resolve/data2_pid> dcterms:identifier "data2_pid" ;
     cito:isDocumentedBy <https://cn.dataone.org/cn/v2/resolve/meta_pid> ;
@@ -33,9 +33,6 @@ ore:Aggregation rdfs:label "Aggregation" ;
     cito:isDocumentedBy <https://cn.dataone.org/cn/v2/resolve/meta_pid> ;
     ore:isAggregatedBy <https://cn.dataone.org/cn/v2/resolve/ore_pid#aggregation> .
 
-<https://cn.dataone.org/cn/v2/resolve/resource2_pid> dcterms:identifier "resource2_pid" ;
-    ore:isAggregatedBy <https://cn.dataone.org/cn/v2/resolve/ore_pid#aggregation> .
-
 <https://cn.dataone.org/cn/v2/resolve/meta_pid> dcterms:identifier "meta_pid" ;
     cito:documents <https://cn.dataone.org/cn/v2/resolve/data2_pid>,
         <https://cn.dataone.org/cn/v2/resolve/data3_pid>,
@@ -47,5 +44,4 @@ ore:Aggregation rdfs:label "Aggregation" ;
         <https://cn.dataone.org/cn/v2/resolve/data3_pid>,
         <https://cn.dataone.org/cn/v2/resolve/data_pid>,
         <https://cn.dataone.org/cn/v2/resolve/meta_pid>,
-        <https://cn.dataone.org/cn/v2/resolve/resource1_pid>,
-        <https://cn.dataone.org/cn/v2/resolve/resource2_pid> .
+        <https://cn.dataone.org/cn/v2/resolve/resource1_pid> .

--- a/test_utilities/src/d1_test/test_docs/sample/test_resource_map_set_documents_mn_v2.sample
+++ b/test_utilities/src/d1_test/test_docs/sample/test_resource_map_set_documents_mn_v2.sample
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .


### PR DESCRIPTION
This PR introduces a method in the ResourceMap object that allows a user to specify the path of a file in the resource map.

### Changes
1. I added the prov namespace to the sample files whose linked unit tests were failing.
2. I also created a new sample file for the unit test that tests `setAtLocation`
3. A new method, `setAtLocation` in the ResourceMap class
4. Added the prov namespace to the ORE


If you see anything that can be done better, feel free to reach out!

Linked to issue #26 