### PR TITLE
Catch when the pid isn't found in the resource map

### DIFF
--- a/lib_common/src/d1_common/resource_map.py
+++ b/lib_common/src/d1_common/resource_map.py
@@ -328,7 +328,8 @@ class ResourceMap(rdflib.ConjunctiveGraph):
         self._check_initialized()
         opid = rdflib.term.Literal(pid)
         res = [o for o in self.subjects(predicate=DCTERMS.identifier, object=opid)]
-        return res[0]
+        if len(res):
+            return res[0]
 
     def addResource(self, pid):
         """Add a resource to the Resource Map.

--- a/lib_common/src/d1_common/resource_map.py
+++ b/lib_common/src/d1_common/resource_map.py
@@ -327,9 +327,11 @@ class ResourceMap(rdflib.ConjunctiveGraph):
       str : URIRef of the entry identified by ``pid``."""
         self._check_initialized()
         opid = rdflib.term.Literal(pid)
-        res = [o for o in self.subjects(predicate=DCTERMS.identifier, object=opid)]
-        if len(res):
+        try:
+            res = [o for o in self.subjects(predicate=DCTERMS.identifier, object=opid)]
             return res[0]
+        except IndexError:
+            raise ValueError('Failed to find the object, {pid}, in the resource map')
 
     def addResource(self, pid):
         """Add a resource to the Resource Map.

--- a/lib_common/src/d1_common/tests/test_resource_map.py
+++ b/lib_common/src/d1_common/tests/test_resource_map.py
@@ -293,6 +293,8 @@ import io
 #
 import warnings
 
+import pytest
+
 import rdflib
 
 import d1_common.resource_map
@@ -469,5 +471,5 @@ class TestResourceMap(d1_test.d1_test_case.D1TestCase):
     def test_1200(self, mn_client_v2):
         """getObjectByPid()"""
         ore = self._create()
-        u = ore.getObjectByPid("non_existing_pid")
-        assert u is None
+        with pytest.raises(ValueError):
+            ore.getObjectByPid("non_existing_pid")

--- a/lib_common/src/d1_common/tests/test_resource_map.py
+++ b/lib_common/src/d1_common/tests/test_resource_map.py
@@ -465,3 +465,9 @@ class TestResourceMap(d1_test.d1_test_case.D1TestCase):
         ore.addResource("resource1_pid")
         ore.setAtLocation("resource1_pid", "scripts/data_cleaning")
         self.sample.assert_equals(ore, "set_at_location", mn_client_v2)
+
+    def test_1200(self, mn_client_v2):
+        """getObjectByPid()"""
+        ore = self._create()
+        u = ore.getObjectByPid("non_existing_pid")
+        assert u is None


### PR DESCRIPTION
Fixes issue #33 

I decided to just return None if the pid wasn't found rather than throwing and exception. Unit test included.