### PR TITLE
Allow overrides of DJANGO_SETTINGS_MODULE in wsgi.py

### DIFF
--- a/gmn/src/d1_gmn/tests/gmn_test_case.py
+++ b/gmn/src/d1_gmn/tests/gmn_test_case.py
@@ -41,7 +41,7 @@ import django.core.management
 import django.db
 import django.test
 
-os.environ["DJANGO_SETTINGS_MODULE"] = "d1_gmn.settings_test"
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "d1_gmn.settings_test")
 django.setup()
 
 import d1_test.test_files

--- a/gmn/src/d1_gmn/wsgi.py
+++ b/gmn/src/d1_gmn/wsgi.py
@@ -28,7 +28,7 @@ import django.http
 import django.utils
 import django.utils.datastructures
 
-os.environ["DJANGO_SETTINGS_MODULE"] = "d1_gmn.settings"
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "d1_gmn.settings")
 
 # Add the service folder to the search path.
 sys.path.append(d1_common.utils.filesystem.abs_path("."))


### PR DESCRIPTION
Set os.environ.setdefault when setting DJANGO_SETTINGS_MODULE in wsgi.py so that other settings modules can be used by setting DJANGO_SETTINGS_MODULE.