### PR TITLE
Upgrade dropbox to fix dependency metadata problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ Django==4.2.1
 doc8==1.1.1
 docopt==0.6.2
 docutils==0.20.1
-dropbox==11.36.0
+dropbox==11.36.2
 elementpath==4.1.2
 execnet==1.9.0
 executing==1.2.0


### PR DESCRIPTION
Upgrade dropbox dependency to 11.36.2 to avoid a dependency metadata issue.

Without this fix, `pip install -r requirements.txt` fails in pip >=24.1 with the following error:

```
WARNING: Ignoring version 11.36.0 of dropbox since it has invalid metadata:
Requested dropbox==11.36.0 from https://files.pythonhosted.org/packages/11/7e/e66327f3535cf5b58b3c152144744fc5727355357304facf61e43ab1b895/dropbox-11.36.0-py3-none-any.whl (from -r requirements.txt (line 46)) has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    stone (>=2.*)
           ~~~~^
Please use pip<24.1 if you need to use this version.
```

Fixed in dropbox-sdk-python here:

https://github.com/dropbox/dropbox-sdk-python/pull/456